### PR TITLE
Add ability to be launched via url-scheme

### DIFF
--- a/Cloudy/Info.plist
+++ b/Cloudy/Info.plist
@@ -16,6 +16,21 @@
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleIdentifier</key>
+			<string></string>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLName</key>
+			<string>com.nomad5.cloudy</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>cloudybrowser</string>
+			</array>
+		</dict>
+	</array>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>ITSAppUsesNonExemptEncryption</key>

--- a/Cloudy/Model/Navigator.swift
+++ b/Cloudy/Model/Navigator.swift
@@ -21,6 +21,15 @@ class Navigator {
             static let patreon        = URL(string: "https://www.patreon.com/cloudyApp")!
             static let paypal         = URL(string: "https://paypal.me/pools/c/8tPw2veZIm")!
         }
+        
+        static var serviceToUrl: [String: URL] = {
+            return [
+                "stadia": Url.googleStadia,
+                "geforceBeta": Url.geforceNowBeta,
+                "geforce": Url.geforceNowOld,
+                "luna": Url.amazonLuna,
+            ]
+        }()
 
         struct UserAgent {
             static let chromeDesktop = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.4280.88 Safari/537.36"

--- a/Cloudy/RootViewController.swift
+++ b/Cloudy/RootViewController.swift
@@ -31,7 +31,9 @@ class RootViewController: UIViewController, MenuActionsHandler {
     @IBOutlet var webviewContstraints: [NSLayoutConstraint]!
 
     /// The hacked webView
-    private var  webView:                                     FullScreenWKWebView!
+    var webView:                                     FullScreenWKWebView!
+    static var browserWindow: RootViewController? // global variable for access.
+    static var launchSite: URL? // A site to launch into.
     private let  navigator:                                   Navigator       = Navigator()
 
     /// The menu controller
@@ -104,7 +106,9 @@ class RootViewController: UIViewController, MenuActionsHandler {
         webView.navigationDelegate = self
         webView.allowsBackForwardNavigationGestures = false
         // initial
-        if let lastVisitedUrl = UserDefaults.standard.lastVisitedUrl {
+        if let launchSiteUrl = Self.launchSite {
+            webView.navigateTo(url: launchSiteUrl)
+        } else if let lastVisitedUrl = UserDefaults.standard.lastVisitedUrl {
             webView.navigateTo(url: lastVisitedUrl)
         } else {
             #if NON_APPSTORE
@@ -125,6 +129,9 @@ class RootViewController: UIViewController, MenuActionsHandler {
         addChild(menuViewController)
         view.addSubview(menuViewController.view)
         menuViewController.didMove(toParent: self)
+        
+        // Now that the view-controller is loaded, save it.
+        Self.browserWindow = self
     }
 
     /// View layout already done

--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ A cloud-gaming ready browser for iOS.
   - `boost` -> launch Boosteroid
 - If you want to go _crazy_, you can specify your custom user agent
 - Ability to reset all cookies and caches
+- For 3rd-party devs: you can launch this app via url-scheme. Examples:
+ - To launch to a specific website `"cloudybrowser://site?url=https://stadia.google.com"`
+ - To launch to a service (`stadia`, `luna`, and `geforce` are supported): `"cloudybrowser://site?service=geforce"`
 
 ## Features in development
 


### PR DESCRIPTION
Added the url-scheme "cloudybrowser" for this app.

Now, a third-party app can launch this app (with specific url to go to, or cloudservice shortname), via the following:

```
let url = URL(string: "cloudybrowser://site?url=https://stadia.google.com")! 
// let url = URL(string: "cloudybrowser://site?service=stadia")! // another method
if UIApplication.shared.canOpenURL(url) {
    UIApplication.shared.open(url, options: [:], completionHandler: { success in
        logger.info("Successfully Launched Cloudy")
    })
}
```